### PR TITLE
Allow model outputs to have units by using the template.

### DIFF
--- a/hydra_pywr/core.py
+++ b/hydra_pywr/core.py
@@ -37,7 +37,7 @@ class BasePywrHydra:
         self.next_resource_attribute_id = -1
 
     def _make_dataset_resource_scenario(self, name, value, data_type, resource_attribute_id,
-                                        encode_to_json=False,):
+                                        encode_to_json=False, unit_id=None):
         """ A helper method to make a dataset, resource attribute and resource scenario. """
 
         # Create a dataset representing the value
@@ -46,6 +46,7 @@ class BasePywrHydra:
             'value': json.dumps(value) if encode_to_json else value,
             "hidden": "N",
             "type": data_type,
+            "unit_id": unit_id,
             "metadata": json.dumps({'json_encoded': encode_to_json})
         }
 

--- a/hydra_pywr/runner.py
+++ b/hydra_pywr/runner.py
@@ -278,11 +278,17 @@ class PywrHydraRunner(PywrHydraExporter):
             # Get the attribute and its ID
             attribute_name = self._get_attribute_name_from_recorder(recorder)
             # Now we need to ensure there is a resource attribute for all nodes and recorder attributes
+            
+            #Get the hydra attribute object to its ID can be used to search for a unit for the dataset
+            attribute = self._get_attribute_from_name(attribute_name)
+
 
             try:
                 recorder_node = self._get_node_from_recorder(recorder)
             except AttributeError:
                 continue
+
+            unit_id = self._get_unit_from_type(recorder_node.name if recorder_node.parent is None else recorder_node.parent.name, attribute.id) 
 
             try:
                 resource_attribute_id = self._get_resource_attribute_id(recorder_node.name, attribute_name)
@@ -297,7 +303,6 @@ class PywrHydraRunner(PywrHydraExporter):
                             break
                 else:
                     continue
-                attribute = self._get_attribute_from_name(attribute_name)
 
                 # Try to get the resource attribute
                 resource_attribute = client.add_resource_attribute('NODE', node_id, attribute['id'], is_var='Y',
@@ -305,7 +310,7 @@ class PywrHydraRunner(PywrHydraExporter):
                 resource_attribute_id = resource_attribute['id']
 
             resource_scenario = self._make_dataset_resource_scenario(recorder.name, value, 'dataframe', resource_attribute_id,
-                                                                     encode_to_json=False)
+                                                                     encode_to_json=False, unit_id=unit_id)
 
             yield resource_scenario
 


### PR DESCRIPTION
Units can be set on a type's attributes in a template. 

If a template type attribute has a unit specified on it, then use this unit when generating the output dataset from the model