### PR TITLE
Update ProportionalInput node factor arg to AggregatedNode member

### DIFF
--- a/hydra_pywr/nodes/hydropower.py
+++ b/hydra_pywr/nodes/hydropower.py
@@ -303,14 +303,15 @@ class ProportionalInput(Input):
     def __init__(self, model, name, node, proportion, **kwargs):
         super().__init__(model, name, **kwargs)
 
-        self.node = node
+        self.node = model.pre_load_node(node)
         # Create the flow factors for the other node and self
         if proportion < 1e-6:
             self.max_flow = 0.0
         else:
             factors = [1, proportion]
             # Create the aggregated node to apply the factors.
-            self.aggregated_node = AggregatedNode(model, f'{name}.aggregated', [node, self], factors=factors)
+            self.aggregated_node = AggregatedNode(model, f'{name}.aggregated', [self.node, self])
+            self.aggregated_node.factors = factors
 
 
 class MonthlyOutputWithReturn(MonthlyOutput):


### PR DESCRIPTION
The format of arguments to `AggregatedNode` has changed in Pywr; this requires a minor change to the `ProportionalInput` node which instantiates an `AggregatedNode` member.