### PR TITLE
Runner uses new add_resource_attributes return type

### DIFF
--- a/hydra_pywr/runner.py
+++ b/hydra_pywr/runner.py
@@ -726,7 +726,10 @@ class PywrHydraRunner(HydraToPywrNetwork):
         for chunk in chunked_iterable(resource_attributes_to_add, 100):
             new_ids = self.hydra.add_resource_attributes(resource_attributes=chunk)
             for i, new_ra in enumerate(chunk):
-                new_ra['id'] = new_ids[i]
+                key = (new_ra["resource_id"], new_ra["attr_id"])
+                if key not in new_ids:
+                    continue
+                new_ra['id'] = new_ids[key]
                 if new_ra['resource_type'] == 'NETWORK':
                     # We need to set the network ID for the resource attribute
                     new_ra['network_id'] = new_ra['resource_id']
@@ -748,7 +751,6 @@ class PywrHydraRunner(HydraToPywrNetwork):
         non_df_recorder_ra_id_map = self.add_resource_attributes(self._non_df_recorders, is_dataframe=False)
 
         for recorder in self._df_recorders:
-            
             try:
                 df = recorder.to_dataframe()
             except NotImplementedError:


### PR DESCRIPTION
This is a minor change which makes use of the new return type added in [hydra-base#269](https://github.com/hydraplatform/hydra-base/pull/269).

Note that this commit was marked `WIP` pending discussion of the adequacy of ignoring (with "continue") rattrs not in the `new_ids` that were added: Can it be assumed these are added into the `self.recorder_ra_id_map` elsewhere and so are not omitted?